### PR TITLE
fix word list length type check

### DIFF
--- a/build/nbp.js
+++ b/build/nbp.js
@@ -300,7 +300,7 @@ var NBP = (function() {
     var cache = arguments[2] !== (void 0) ? arguments[2] : true;
     var wordlistSplit = wordlist.split("_"),
         wordlistLength = wordlistSplit[wordlistSplit.length - 1];
-    if (typeof wordlistLength === "number") {
+    if (typeof wordlistLength !== "number") {
       console.error('[NBP] Provided wordlist file must match the format [list description]_[list length]');
       console.error('i.e. mostcommon_10000');
       return false;


### PR DESCRIPTION
Hit an issue where this never fired when I changed the file name pattern. Ended up with a misconfigured bloomfilter since the word list length result ends up being `NaN` 
